### PR TITLE
feat: set publishOnNpm parameters on Jenkins pipeline 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,5 +12,6 @@ library(
 )
 
 zappPipeline(
-    publishOnNpm: true
+    publishOnNpm: true,
+    disableAutoTranslationsSync: true
 )


### PR DESCRIPTION
The publishOnNpm parameter allows publishing the built package on the npm registry