### PR TITLE
ci: add build:dev script for dev mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
 		"deploy": "sdk deploy --admin",
 		"start": "sdk watch --admin",
 		"pull-translations": "git subtree pull -P translations git@github.com:Zextras/carbonio-admin-ui-i18n.git master --squash",
-		"push-translations": "git subtree push -P translations git@github.com:Zextras/carbonio-admin-ui-i18n.git"
+		"push-translations": "git subtree push -P translations git@github.com:Zextras/carbonio-admin-ui-i18n.git",
+		"build:dev": "sdk build --dev --pkgRel $(date +%s)"
 	},
 	"files": [
 		"dist/",


### PR DESCRIPTION
To make common pipeline support different bundlers, we need to remove references to the sdk from it and move them inside projects scripts. build:dev is the script in charge of creating the build in dev mode. Related to zextras/jenkins-zapp-lib#13